### PR TITLE
maintain setuptools compatibility with pytorch

### DIFF
--- a/create_environment.sh
+++ b/create_environment.sh
@@ -11,6 +11,6 @@ conda create -y -n adop python=3.9.7
 conda activate adop
 
 conda install -y cudnn=8.2.1.32 cudatoolkit-dev=11.2 cudatoolkit=11.2 -c nvidia -c conda-forge
-conda install -y astunparse numpy ninja pyyaml mkl mkl-include setuptools cmake=3.19.6 cffi typing_extensions future six requests dataclasses pybind11=2.6.2
+conda install -y astunparse numpy ninja pyyaml mkl mkl-include setuptools=59.5.0 cmake=3.19.6 cffi typing_extensions future six requests dataclasses pybind11=2.6.2
 conda install -y magma-cuda110 -c pytorch
 conda install -y freeimage=3.17 jpeg=9d protobuf=3.13 -c conda-forge


### PR DESCRIPTION
With the introduction of [setuptools-59.6.0](https://github.com/pypa/setuptools/tree/v59.6.0) distutils is a private module, and we should not be importing versions directly. This was already fixed in pytorch  with https://github.com/pytorch/pytorch/pull/69904 but to avoid introducing more breaking changes, I propose freezing the setuptools version to 59.5.0.